### PR TITLE
Add a no-op clean build to make jhbuild happy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,8 @@ dist:
 	cp *.ttf *.otf Makefile webkitgtk-test-fonts-0.0.1
 	tar cvzf webkitgtk-test-fonts-0.0.1.tar.gz webkitgtk-test-fonts-0.0.1
 	rm -rf webkitgtk-test-fonts-0.0.1
+
+clean:
+	@true
+
+.PHONY: clean


### PR DESCRIPTION
<tomz> Has anyone seen the following on a fresh webkit build of GTK+?  No rule to make target 'clean' during 'phase clean of fonts'?
 or is there a better place to ask?
<kov> tomz, is your build erroring out because of that?
<tomz> kov: yes
 kov: technically it goes on and then errors at the end because 'fonts' was not built
<kov> =( it should not error out because of that, you can probably work it around by adding an empty clean target to WebKitBuild/Dependencies/Source/webkitgtk-test-fonts-0.0.1/Makefile
<tomz> kov: thanks!! i'll try it, and also try to figure out why it's erroring out if it shouldn't.
<kov> that'd be great =)
 I guess we can just add that clean target to make jhbuild a happier panda
